### PR TITLE
Init Project 2.0

### DIFF
--- a/.github/workflows/enforce-dev-to-main.yml
+++ b/.github/workflows/enforce-dev-to-main.yml
@@ -1,0 +1,14 @@
+name: Enforce only dev merges into main
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for dev as source branch
+        if: github.head_ref != 'dev'
+        run: |
+          echo "Error: Pull requests to 'main' can only originate from the 'dev' branch."
+          exit 1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/vienesse-consulting/Digital-Assessment
+module github.com/AntiB-Projects/agentic_go
 
 go 1.24.4


### PR DESCRIPTION
- change name to correct repository
- added github workflow to enforce only `dev` can merge into `main`